### PR TITLE
Process partitions individually

### DIFF
--- a/queries/match.sql
+++ b/queries/match.sql
@@ -7,9 +7,9 @@ attributes->>'gameMode' AS "gameMode",
 COALESCE(NULLIF(attributes->>'patchVersion', ''), '0') AS "patchVersion",
 attributes->>'shardId' AS "shardId",
 attributes->'stats'->>'endGameReason' AS "endGameReason",
-attributes->'stats'->>'queue' AS "queue",
+attributes->'stats'->>'queue' AS "queue" --,
 
-relationships->'rosters'->'data'->0->>'id' as roster_1,
-relationships->'rosters'->'data'->1->>'id' as roster_2
+--relationships->'rosters'->'data'->0->>'id' as "roster_1",
+--relationships->'rosters'->'data'->1->>'id' as "roster_2"
 
 FROM "match"

--- a/queries/match.sql
+++ b/queries/match.sql
@@ -12,4 +12,4 @@ attributes->'stats'->>'queue' AS "queue",
 relationships->'rosters'->'data'->0->>'id' as roster_1,
 relationships->'rosters'->'data'->1->>'id' as roster_2
 
-FROM match
+FROM "match"

--- a/queries/participant.sql
+++ b/queries/participant.sql
@@ -25,4 +25,4 @@ attributes->'stats'->'itemSells' AS "itemSells",
 attributes->'stats'->'itemUses' AS "itemUses",
 attributes->'stats'->'items' AS "items"
 
-FROM participant
+FROM "participant"

--- a/queries/participant.sql
+++ b/queries/participant.sql
@@ -1,7 +1,7 @@
 SELECT
 
 id AS "apiId",
-relationships->'player'->'data'->>'id' AS "player_apiId",
+relationships->'player'->'data'->>'id' AS "playerId",
 
 attributes->>'actor' AS "hero",
 (attributes->'stats'->>'assists')::int AS "assists",

--- a/queries/player.sql
+++ b/queries/player.sql
@@ -12,4 +12,4 @@ attributes->>'name' AS "name",
 
 0 AS "streak"
 
-FROM player
+FROM "player"

--- a/queries/roster.sql
+++ b/queries/roster.sql
@@ -14,4 +14,4 @@ relationships->'participants'->'data'->0->>'id' AS "participant_1",
 relationships->'participants'->'data'->1->>'id' AS "participant_2",
 relationships->'participants'->'data'->2->>'id' AS "participant_3"
 
-FROM roster
+FROM "roster"


### PR DESCRIPTION
Depends on vainglorygame/apigrabber#29
Fixes #8, fixes #5 

Each table partition is processed in one job. When a partition changes, it is currently *not* updated via Processor. Run Apigrabber first until it finishes before you run Processor.

Also fixed two SQL queries that caused error during development, you might want to look at the change and revert it.